### PR TITLE
Update NextAuthConfig to use GithubProvider directly

### DIFF
--- a/articles/2c347e04601f09.md
+++ b/articles/2c347e04601f09.md
@@ -63,10 +63,7 @@ import GithubProvider from "next-auth/providers/github";
 
 const config: NextAuthConfig = {
   providers: [
-    GithubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET,
-    }),
+    GithubProvider
   ],
   basePath: "/api/auth",
 };


### PR DESCRIPTION
This pull request updates the NextAuthConfig file to use the GithubProvider directly instead of passing the client ID and client secret as environment variables. This change simplifies the configuration and improves the readability of the code.

環境変数から勝手に読み取ってくれるはずだからいらないと思うヨ